### PR TITLE
Fixes #6 Sign I button resolved to 2 elements

### DIFF
--- a/src/amazon_invoice_downloader/cli/__init__.py
+++ b/src/amazon_invoice_downloader/cli/__init__.py
@@ -95,7 +95,7 @@ def run(playwright, args):
         page.get_by_label("Password").click()
         page.get_by_label("Password").fill(password)
         page.get_by_label("Keep me signed in").check()
-        page.get_by_role("button", name="Sign in").click()
+        page.get_by_role("button", name="Sign in", exact=True).click()
 
     page.wait_for_selector('a >> text=Returns & Orders', timeout=0).click()
     sleep()


### PR DESCRIPTION
This resolves #6 in my testing.
The problem is that "Sign In" and "Sign in with passkey" are both buttons and when you don't set `exact=True` it does a contains to find the proper element.