### PR TITLE
Fix invoices not downloading due to outdated selector

### DIFF
--- a/src/amazon_invoice_downloader/cli/__init__.py
+++ b/src/amazon_invoice_downloader/cli/__init__.py
@@ -134,7 +134,7 @@ def run(playwright, args):
                 break
 
             # Order Loop
-            order_cards = page.query_selector_all(".order.js-order-card")
+            order_cards = page.query_selector_all(".order-card.js-order-card")
             for order_card in order_cards:
                 # Parse the order card to create the date and file_name
                 spans = order_card.query_selector_all("span")


### PR DESCRIPTION
It seems that Amazon recently updated its website, preventing the script from downloading invoices until I adjusted the selector. 

I figured I’d open a PR in case others are experiencing the same issue.

Thank you for providing this script. It’s been a huge time saver!